### PR TITLE
[BUGFIX] RenderViewHelper: Do not escape HTML output

### DIFF
--- a/Classes/ViewHelpers/RenderViewHelper.php
+++ b/Classes/ViewHelpers/RenderViewHelper.php
@@ -56,7 +56,13 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class RenderViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
 {
-
+    /**
+     * As this ViewHelper renders HTML, the output must not be escaped.
+     *
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+    
     /**
      * @param string $template
      * @param array $settings


### PR DESCRIPTION
Disable Fluid's automatic escaping of the render view helper output.

Resolves: #16 