### PR TITLE
[BUGFIX] PHP 8.1 Warnings

### DIFF
--- a/Classes/Engine/HandlebarsEngine.php
+++ b/Classes/Engine/HandlebarsEngine.php
@@ -98,8 +98,8 @@ class HandlebarsEngine
         $this->templatesRootPath = $settings['templatesRootPath'] ?? null;
         $this->partialsRootPath = $settings['partialsRootPath'] ?? null;
         $this->template = $settings['template'] ?? $settings['templatePath'] ?? null;
-        $this->dataProviders = $settings['dataProviders'];
-        $this->additionalData = $settings['additionalData'];
+        $this->dataProviders = $settings['dataProviders'] ?? [];
+        $this->additionalData = $settings['additionalData'] ?? [];
         $this->tempPath = Environment::getPublicPath() . '/' . $settings['tempPath'];
     }
 


### PR DESCRIPTION
Fix code which might produce warnings in PHP 8.1.
Array entries are optional and don't always exist. Add proper fallback.